### PR TITLE
Fix issue with failed OOO upgrade

### DIFF
--- a/infrared_plugin/main.yml
+++ b/infrared_plugin/main.yml
@@ -30,15 +30,15 @@
 
     - name: Set upgrade workload disk size
       set_fact:
-         workload_disk: "{{ install.upgrade.workload.disk }}"
+         workload_disk: "{{ install.upgrade.workloaddisk }}"
 
     - name: Set upgrade workload vcpus
       set_fact:
-         workload_vcpu: "{{ install.upgrade.workload.vcpu }}"
+         workload_vcpu: "{{ install.upgrade.workloadvcpu }}"
 
     - name: Set upgrade workload swap
       set_fact:
-         workload_swap: "{{ install.upgrade.workload.swap }}"
+         workload_swap: "{{ install.upgrade.workloadswap }}"
 
     - name: Set upgrade workload post_composable_upgrade launch
       set_fact:

--- a/infrared_plugin/plugin.spec
+++ b/infrared_plugin/plugin.spec
@@ -60,17 +60,17 @@ subparsers:
                       help: |
                           User used for conecting to workload instance via SSH
                       default: cirros
-                  upgrade-workload-disk:
+                  upgrade-workloaddisk:
                       type: Value
                       help: |
                           Disk size assigned to the instance spawned before upgrade
                       default: 5
-                  upgrade-workload-vcpu:
+                  upgrade-workloadvcpu:
                       type: Value
                       help: |
                           Amount of vcpus assigned to the instance spawned before upgrade
                       default: 1
-                  upgrade-workload-swap:
+                  upgrade-workloadswap:
                       type: Value
                       help: |
                           Swap size assigned to the instance spawned before upgrade


### PR DESCRIPTION
The reason of issue is in the structure of variables in plugins.spec. Since
infrared converts varibles from plugin.spec to dict, there is some limitations
and following example won't work.

For example:
  example-key: value
  example-key-foo: value1
  example-key-bar: value2

Change-Id: I50ca550d225e52ba44b76a70b1db1c34088b88d9