### PR TITLE
Fixing overcloud_update_prepare comment line breaking

### DIFF
--- a/templates/overcloud_update_prepare.sh.j2
+++ b/templates/overcloud_update_prepare.sh.j2
@@ -40,7 +40,7 @@ openstack overcloud update prepare --templates {{ tht_directory }} \
     -e {{ working_dir }}/{{ install.deployment.files | basename }}/config_heat_extra.yaml \
     {% endif -%}
     {% if rhsm_overcloud_env != '' -%}
-    # adding rhsm at the end so it overrides any other rhsm params passed.
+    {{# adding rhsm at the end so it overrides any other rhsm params passed. #}}
     -e /usr/share/openstack-tripleo-heat-templates/environments/rhsm.yaml \
     -e {{ rhsm_overcloud_env }} \
     {% endif -%}


### PR DESCRIPTION
The Jinja script for overcloud_update_prerpare was breaking in case the rhsm condition is true, a comment was causing a line break and the script ended with error: /home/stack/overcloud_update_prepare.sh: line 31: -e: command not found